### PR TITLE
os.makedirs 오류 해결

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 Korean text data preprocess toolkit for NLP
 
 ## Overview
-This repository contains codes for korean text preprocessing. There are several options you can use for now. Other functions will be added sooner or later.
+This repository contains codes for Korean text preprocessing. There are several options you can use for now. Other functions will be added sooner or later.
 
 ### Options
-* `clean_kor` is for cleaning korean text data like 'sejong corpus'. It will trim the unnecessary character and symbols.
+* `clean_kor` is for cleaning Korean text data like 'sejong corpus'. It will trim the unnecessary character and symbols.
 
-* `mecab` is for morphological analysis. It provides `morphs`, `nouns`, `pos` functions for your korean text data and of course, each are selectable by additional option.
+* `mecab` is for morphological analysis. It provides `morphs`, `nouns`, `pos` functions for your Korean text data and of course, each are selectable by additional option.
 Check [KoNLPy](http://konlpy.org/en/latest/) out in detail.
 
 * `NLP` for text data templating for certain task. For now, `next_sentence_prediction` template is only available. It arranges two sentences in a line with seperator [SEP]. Please read the description in `src/tasks.py`. Other task templates will be added in the list. 

--- a/main.py
+++ b/main.py
@@ -15,9 +15,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument("-i", "--input", \
-                        required=True, type=str, help="Input file dir")
+                        required=True, type=str, help="Input file name")
     parser.add_argument("-o", "--output", \
-                        type=str, default="ouput.txt", help="Output file dir")
+                        type=str, default="ouput.txt", help="Output file name")
     parser.add_argument("-opt", "--option", \
                         required=True, type=str, default=None, \
                         choices=opt_availables, help="Which option to apply.")

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     filepath = os.path.dirname(os.path.normpath(args.output))
-    if  filepath != '':
+    if  filepath:
         os.makedirs(filepath, exist_ok=True)
 
     if args.option == 'tokenize':

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     parser.add_argument("-i", "--input", \
                         required=True, type=str, help="Input file dir")
     parser.add_argument("-o", "--output", \
-                        type=str, default=None, help="Output file dir")
+                        type=str, default="ouput.txt", help="Output file dir")
     parser.add_argument("-opt", "--option", \
                         required=True, type=str, default=None, \
                         choices=opt_availables, help="Which option to apply.")
@@ -38,7 +38,9 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    os.makedirs(os.path.dirname(os.path.normpath(args.output)) or './', exist_ok=True)
+    filepath = os.path.dirname(os.path.normpath(args.output))
+    if  filepath != '':
+        os.makedirs(filepath, exist_ok=True)
 
     if args.option == 'tokenize':
         opt = Tokenizer(args)


### PR DESCRIPTION
기존 - os.makedirs에서 인자로 쓰이는 os.normpath가 NoneType을 받으면 에러가 뜨는 문제가 있었음.
수정 - args.output의 default 값을 None에서 "output.txt"로 바꿈. 이렇게 할 경우 dirname이 공백이 되기 때문에 조건문을 달아서 경로가 공백이 아닌 경우에만 makedirs를 하도록 수정.